### PR TITLE
Add limb examining

### DIFF
--- a/Content.Server/Examine/ExamineSystem.cs
+++ b/Content.Server/Examine/ExamineSystem.cs
@@ -69,7 +69,11 @@ namespace Content.Server.Examine
             if (request.GetVerbs)
                 verbs = _verbSystem.GetLocalVerbs(entity, playerEnt, typeof(ExamineVerb));
 
-            var text = GetExamineText(entity, player.AttachedEntity);
+            EntityUid? targetPart = null;
+            if (request.TargetPart.HasValue)
+                targetPart = GetEntity(request.TargetPart.Value);
+
+            var text = GetExamineText(entity, player.AttachedEntity, targetPart);
             RaiseNetworkEvent(new ExamineSystemMessages.ExamineInfoResponseMessage(
                 request.NetEntity, request.Id, text, verbs?.ToList()), channel);
         }

--- a/Content.Shared/Body/Prototypes/BodyPrototype.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototype.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Prototypes;
+using System.Numerics;
 
 namespace Content.Shared.Body.Prototypes;
 
@@ -26,4 +27,4 @@ public sealed partial class BodyPrototype : IPrototype
 }
 
 [DataRecord]
-public sealed partial record BodyPrototypeSlot(EntProtoId? Part, HashSet<string> Connections, Dictionary<string, string> Organs);
+public sealed partial record BodyPrototypeSlot(EntProtoId? Part, HashSet<string> Connections, Dictionary<string, string> Organs, Vector2 Offset);

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -163,7 +163,7 @@ public partial class SharedBodySystem
                 // Spawn the entity on the target
                 // then get the body part type, create the slot, and finally
                 // we can insert it into the container.
-                var childPart = Spawn(connectionSlot.Part, new EntityCoordinates(parentEntity, Vector2.Zero));
+                var childPart = Spawn(connectionSlot.Part, new EntityCoordinates(parentEntity, connectionSlot.Offset));
                 cameFromEntities[connection] = childPart;
 
                 var childPartComponent = Comp<BodyPartComponent>(childPart);

--- a/Content.Shared/Examine/ExamineSystemMessages.cs
+++ b/Content.Shared/Examine/ExamineSystemMessages.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Verbs;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
+using Robust.Shared.Network;
 
 namespace Content.Shared.Examine
 {
@@ -14,12 +15,14 @@ namespace Content.Shared.Examine
             public readonly int Id;
 
             public readonly bool GetVerbs;
+            public readonly NetEntity? TargetPart;
 
-            public RequestExamineInfoMessage(NetEntity netEntity, int id, bool getVerbs=false)
+            public RequestExamineInfoMessage(NetEntity netEntity, int id, bool getVerbs=false, NetEntity? targetPart = null)
             {
                 NetEntity = netEntity;
                 Id = id;
                 GetVerbs = getVerbs;
+                TargetPart = targetPart;
             }
         }
 

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -253,7 +253,7 @@ namespace Content.Shared.Examine
             return InRangeUnOccluded(originPos, other, range, predicate, ignoreInsideBlocker);
         }
 
-        public FormattedMessage GetExamineText(EntityUid entity, EntityUid? examiner)
+        public FormattedMessage GetExamineText(EntityUid entity, EntityUid? examiner, EntityUid? targetPart = null)
         {
             var message = new FormattedMessage();
 
@@ -276,7 +276,7 @@ namespace Content.Shared.Examine
 
             // Raise the event and let things that subscribe to it change the message...
             var isInDetailsRange = IsInDetailsRange(examiner.Value, entity);
-            var examinedEvent = new ExaminedEvent(message, entity, examiner.Value, isInDetailsRange, hasDescription);
+            var examinedEvent = new ExaminedEvent(message, entity, examiner.Value, isInDetailsRange, hasDescription, targetPart);
             RaiseLocalEvent(entity, examinedEvent);
 
             var newMessage = examinedEvent.GetTotalMessage();
@@ -332,13 +332,19 @@ namespace Content.Shared.Examine
 
         private ExamineMessagePart? _currentGroupPart;
 
-        public ExaminedEvent(FormattedMessage message, EntityUid examined, EntityUid examiner, bool isInDetailsRange, bool hasDescription)
+        /// <summary>
+        ///     Целевая конечность, на которую навёл курсор экзаменующий.
+        /// </summary>
+        public EntityUid? TargetPart { get; }
+
+        public ExaminedEvent(FormattedMessage message, EntityUid examined, EntityUid examiner, bool isInDetailsRange, bool hasDescription, EntityUid? targetPart)
         {
             Message = message;
             Examined = examined;
             Examiner = examiner;
             IsInDetailsRange = isInDetailsRange;
             _hasDescription = hasDescription;
+            TargetPart = targetPart;
         }
 
         /// <summary>

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -115,6 +115,12 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         var age = GetAgeRepresentation(component.Species, component.Age);
 
         args.PushText(Loc.GetString("humanoid-appearance-component-examine", ("user", identity), ("age", age), ("species", species)));
+
+        if (args.TargetPart != null)
+        {
+            var partName = Identity.Name(args.TargetPart.Value, EntityManager);
+            args.PushMarkup(Loc.GetString("examined-limb", ("part", partName)));
+        }
 		
         var examinerPos = _transform.GetWorldPosition(args.Examiner);
         var targetPos = _transform.GetWorldPosition(args.Examined);

--- a/Resources/Locale/en-US/examine/examine-system.ftl
+++ b/Resources/Locale/en-US/examine/examine-system.ftl
@@ -11,3 +11,4 @@ examinable-anchored = It is [color=darkgreen]anchored[/color] to the floor.
 examinable-unanchored = It is [color=darkred]unanchored[/color] from the floor.
 
 examine-distance = Distance: {$distance}
+examined-limb = Limb: {$part}

--- a/Resources/Prototypes/Body/Prototypes/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/animal.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -15,10 +16,12 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"
 
 - type: body
   id: Mouse
@@ -27,6 +30,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -37,7 +41,9 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/Animal/bloodsucker.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/bloodsucker.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -15,7 +16,9 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/Animal/hemocyanin.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/hemocyanin.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -15,7 +16,9 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/Animal/nymph.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/nymph.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -16,10 +17,12 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"
 
 - type: body
   id: AnimalNymphLungs
@@ -28,6 +31,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -38,10 +42,12 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"
 
 - type: body
   id: AnimalNymphStomach
@@ -50,6 +56,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -60,7 +67,9 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/Animal/ruminant.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/ruminant.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -16,7 +17,9 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/slimes.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoSlime
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -12,7 +13,9 @@
         lungs: OrganSlimesLungs
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/Specific/mothroach.yml
+++ b/Resources/Prototypes/Body/Prototypes/Specific/mothroach.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       organs:
         lungs: OrganAnimalLungs
         stomach: OrganMothStomach

--- a/Resources/Prototypes/Body/Prototypes/Specific/smartcorgi.yml
+++ b/Resources/Prototypes/Body/Prototypes/Specific/smartcorgi.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - righthand
       - lefthand
@@ -18,11 +19,15 @@
         kidneys: OrganAnimalKidneys
     lefthand:
       part: LeftHandSmartCorgi
+  offset: "0,0"
     righthand:
       part: RightHandSmartCorgi
+  offset: "0,0"
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/a_ghost.yml
+++ b/Resources/Prototypes/Body/Prototypes/a_ghost.yml
@@ -5,18 +5,23 @@
   slots:
     torso:
       part: TorsoHuman
+  offset: "0,0"
       connections:
       - right_arm
       - left_arm
     right_arm:
       part: RightArmHuman
+  offset: "0,0"
       connections:
       - right_hand
     left_arm:
       part: LeftArmHuman
+  offset: "0,0"
       connections:
       - left_hand
     right_hand:
       part: RightHandHuman
+  offset: "0,0"
     left_hand:
       part: LeftHandHuman
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/arachnid.yml
+++ b/Resources/Prototypes/Body/Prototypes/arachnid.yml
@@ -5,6 +5,7 @@
   slots:
     head:
       part: HeadArachnid
+  offset: "0,0"
       connections:
       - torso
       organs:
@@ -12,6 +13,7 @@
         eyes: OrganArachnidEyes
     torso:
       part: TorsoArachnid
+  offset: "0,0"
       organs:
         heart: OrganArachnidHeart
         lungs: OrganAnimalLungs
@@ -25,25 +27,33 @@
       - left leg
     right arm:
       part: RightArmArachnid
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmArachnid
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandArachnid
+  offset: "0,0"
     left hand:
       part: LeftHandArachnid
+  offset: "0,0"
     right leg:
       part: RightLegArachnid
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegArachnid
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootArachnid
+  offset: "0,0"
     left foot:
       part: LeftFootArachnid
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/bot.yml
+++ b/Resources/Prototypes/Body/Prototypes/bot.yml
@@ -5,3 +5,4 @@
   slots:
     hand 1:
       part: LeftArmBorg
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/diona.yml
+++ b/Resources/Prototypes/Body/Prototypes/diona.yml
@@ -5,12 +5,14 @@
   slots:
     head:
       part: HeadDiona
+  offset: "0,0"
       connections:
       - torso
       organs:
         brain: OrganDionaBrainNymph
     torso:
       part: TorsoDiona
+  offset: "0,0"
       connections:
       - right arm
       - left arm
@@ -21,25 +23,33 @@
         lungs: OrganDionaLungsNymph
     right arm:
       part: RightArmDiona
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmDiona
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandDiona
+  offset: "0,0"
     left hand:
       part: LeftHandDiona
+  offset: "0,0"
     right leg:
       part: RightLegDiona
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegDiona
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootDiona
+  offset: "0,0"
     left foot:
       part: LeftFootDiona
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/dwarf.yml
+++ b/Resources/Prototypes/Body/Prototypes/dwarf.yml
@@ -5,6 +5,7 @@
   slots:
     head:
       part: HeadHuman
+  offset: "0,0"
       connections:
       - torso
       organs:
@@ -12,6 +13,7 @@
         eyes: OrganHumanEyes
     torso:
       part: TorsoHuman
+  offset: "0,0"
       connections:
       - right arm
       - left arm
@@ -25,25 +27,33 @@
         kidneys: OrganHumanKidneys
     right arm:
       part: RightArmHuman
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmHuman
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandHuman
+  offset: "0,0"
     left hand:
       part: LeftHandHuman
+  offset: "0,0"
     right leg:
       part: RightLegHuman
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegHuman
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootHuman
+  offset: "0,0"
     left foot:
       part: LeftFootHuman
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/gingerbread.yml
+++ b/Resources/Prototypes/Body/Prototypes/gingerbread.yml
@@ -5,6 +5,7 @@
   slots:
     head:
       part: HeadGingerbread
+  offset: "0,0"
       connections:
       - torso
       organs:
@@ -12,6 +13,7 @@
         eyes: OrganHumanEyes
     torso:
       part: TorsoGingerbread
+  offset: "0,0"
       connections:
       - right arm
       - left arm
@@ -25,25 +27,33 @@
         kidneys: OrganHumanKidneys
     right arm:
       part: RightArmGingerbread
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmGingerbread
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandGingerbread
+  offset: "0,0"
     left hand:
       part: LeftHandGingerbread
+  offset: "0,0"
     right leg:
       part: RightLegGingerbread
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegGingerbread
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootGingerbread
+  offset: "0,0"
     left foot:
       part: LeftFootGingerbread
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/human.yml
+++ b/Resources/Prototypes/Body/Prototypes/human.yml
@@ -5,6 +5,7 @@
   slots:
     head:
       part: HeadHuman
+      offset: "0,1"
       connections:
       - torso
       organs:
@@ -12,6 +13,7 @@
         eyes: OrganHumanEyes
     torso:
       part: TorsoHuman
+      offset: "0,0"
       connections:
       - right_arm
       - left_arm
@@ -25,25 +27,33 @@
         kidneys: OrganHumanKidneys
     right_arm:
       part: RightArmHuman
+      offset: "0.5,0"
       connections:
       - right_hand
     left_arm:
       part: LeftArmHuman
+      offset: "-0.5,0"
       connections:
       - left_hand
     right_hand:
       part: RightHandHuman
+      offset: "0.75,-0.5"
     left_hand:
       part: LeftHandHuman
+      offset: "-0.75,-0.5"
     right_leg:
       part: RightLegHuman
+      offset: "0.25,-1"
       connections:
       - right_foot
     left_leg:
       part: LeftLegHuman
+      offset: "-0.25,-1"
       connections:
       - left_foot
     right_foot:
       part: RightFootHuman
+      offset: "0.25,-1.5"
     left_foot:
       part: LeftFootHuman
+      offset: "-0.25,-1.5"

--- a/Resources/Prototypes/Body/Prototypes/moth.yml
+++ b/Resources/Prototypes/Body/Prototypes/moth.yml
@@ -5,6 +5,7 @@
   slots:
     head:
       part: HeadMoth
+  offset: "0,0"
       connections:
       - torso
       organs:
@@ -12,6 +13,7 @@
         eyes: OrganHumanEyes
     torso:
       part: TorsoMoth
+  offset: "0,0"
       organs:
         heart: OrganAnimalHeart
         lungs: OrganHumanLungs
@@ -25,25 +27,33 @@
       - left leg
     right arm:
       part: RightArmMoth
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmMoth
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandMoth
+  offset: "0,0"
     left hand:
       part: LeftHandMoth
+  offset: "0,0"
     right leg:
       part: RightLegMoth
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegMoth
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootMoth
+  offset: "0,0"
     left foot:
       part: LeftFootMoth
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/primate.yml
+++ b/Resources/Prototypes/Body/Prototypes/primate.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoAnimal
+  offset: "0,0"
       connections:
       - hands
       - legs
@@ -16,9 +17,12 @@
         kidneys: OrganAnimalKidneys
     hands:
       part: HandsAnimal
+  offset: "0,0"
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/rat.yml
+++ b/Resources/Prototypes/Body/Prototypes/rat.yml
@@ -5,6 +5,7 @@
   slots:
     torso:
       part: TorsoRat
+  offset: "0,0"
       connections:
       - legs
       organs:
@@ -15,7 +16,9 @@
         kidneys: OrganAnimalKidneys
     legs:
       part: LegsAnimal
+  offset: "0,0"
       connections:
       - feet
     feet:
       part: FeetAnimal
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/reptilian.yml
+++ b/Resources/Prototypes/Body/Prototypes/reptilian.yml
@@ -5,6 +5,7 @@
   slots:
     head:
       part: HeadReptilian
+  offset: "0,0"
       connections:
       - torso
       organs:
@@ -12,6 +13,7 @@
         eyes: OrganHumanEyes
     torso:
       part: TorsoReptilian
+  offset: "0,0"
       organs:
         heart: OrganAnimalHeart
         lungs: OrganHumanLungs
@@ -25,25 +27,33 @@
       - left leg
     right arm:
       part: RightArmReptilian
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmReptilian
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandReptilian
+  offset: "0,0"
     left hand:
       part: LeftHandReptilian
+  offset: "0,0"
     right leg:
       part: RightLegReptilian
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegReptilian
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootReptilian
+  offset: "0,0"
     left foot:
       part: LeftFootReptilian
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/skeleton.yml
+++ b/Resources/Prototypes/Body/Prototypes/skeleton.yml
@@ -5,10 +5,12 @@
   slots:
     head:
       part: HeadSkeleton
+  offset: "0,0"
       connections:
       - torso
     torso:
       part: TorsoSkeleton
+  offset: "0,0"
       connections:
       - right arm
       - left arm
@@ -16,25 +18,33 @@
       - left leg
     right arm:
       part: RightArmSkeleton
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmSkeleton
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandSkeleton
+  offset: "0,0"
     left hand:
       part: LeftHandSkeleton
+  offset: "0,0"
     right leg:
       part: RightLegSkeleton
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegSkeleton
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootSkeleton
+  offset: "0,0"
     left foot:
       part: LeftFootSkeleton
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/slime.yml
+++ b/Resources/Prototypes/Body/Prototypes/slime.yml
@@ -5,10 +5,12 @@
   slots:
     head:
       part: HeadSlime
+  offset: "0,0"
       connections:
       - torso
     torso:
       part: TorsoSlime
+  offset: "0,0"
       connections:
       - right arm
       - left arm
@@ -19,25 +21,33 @@
         lungs: OrganSlimeLungs
     right arm:
       part: RightArmSlime
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmSlime
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandSlime
+  offset: "0,0"
     left hand:
       part: LeftHandSlime
+  offset: "0,0"
     right leg:
       part: RightLegSlime
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegSlime
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootSlime
+  offset: "0,0"
     left foot:
       part: LeftFootSlime
+  offset: "0,0"

--- a/Resources/Prototypes/Body/Prototypes/vox.yml
+++ b/Resources/Prototypes/Body/Prototypes/vox.yml
@@ -5,6 +5,7 @@
   slots:
     head:
       part: HeadVox
+  offset: "0,0"
       connections:
       - torso
       organs:
@@ -12,6 +13,7 @@
         eyes: OrganHumanEyes
     torso:
       part: TorsoVox
+  offset: "0,0"
       connections:
       - right arm
       - left arm
@@ -25,25 +27,33 @@
         kidneys: OrganHumanKidneys
     right arm:
       part: RightArmVox
+  offset: "0,0"
       connections:
       - right hand
     left arm:
       part: LeftArmVox
+  offset: "0,0"
       connections:
       - left hand
     right hand:
       part: RightHandVox
+  offset: "0,0"
     left hand:
       part: LeftHandVox
+  offset: "0,0"
     right leg:
       part: RightLegVox
+  offset: "0,0"
       connections:
       - right foot
     left leg:
       part: LeftLegVox
+  offset: "0,0"
       connections:
       - left foot
     right foot:
       part: RightFootVox
+  offset: "0,0"
     left foot:
       part: LeftFootVox
+  offset: "0,0"


### PR DESCRIPTION
## Summary
- add offset property for limb slots in body prototypes
- position spawned body parts at offset instead of origin
- extend examine network message to send selected limb
- show selected limb when examining humanoids
- default offset fields in body prototype YAML files

## Testing
- `dotnet test --no-build` *(fails: unable to fetch packages)*