### PR TITLE
Add toggle prone hotkey

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -74,6 +74,7 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
+            human.AddFunction(ContentKeyFunctions.ToggleProne);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);
             human.AddFunction(ContentKeyFunctions.RotateObjectClockwise);
             human.AddFunction(ContentKeyFunctions.RotateObjectCounterclockwise);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -199,6 +199,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.RotateObjectClockwise);
             AddButton(ContentKeyFunctions.RotateObjectCounterclockwise);
             AddButton(ContentKeyFunctions.FlipObject);
+            AddButton(ContentKeyFunctions.ToggleProne);
 
             AddHeader("ui-options-header-ui");
             AddButton(ContentKeyFunctions.FocusChat);

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -33,6 +33,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
         public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
+        public static readonly BoundKeyFunction ToggleProne = "ToggleProne";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";
         public static readonly BoundKeyFunction SwapHands = "SwapHands";
         public static readonly BoundKeyFunction SwapHandsReverse = "SwapHandsReverse";

--- a/Content.Shared/Standing/ToggleProneSystem.cs
+++ b/Content.Shared/Standing/ToggleProneSystem.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Input;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+
+namespace Content.Shared.Standing;
+
+public sealed class ToggleProneSystem : EntitySystem
+{
+    [Dependency] private readonly StandingStateSystem _standing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.ToggleProne, InputCmdHandler.FromDelegate(HandleToggle, handle: false))
+            .Register<ToggleProneSystem>();
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        CommandBinds.Unregister<ToggleProneSystem>();
+    }
+
+    private void HandleToggle(ICommonSession? session)
+    {
+        if (session?.AttachedEntity is not { Valid: true } uid || !Exists(uid))
+            return;
+
+        if (!TryComp<StandingStateComponent>(uid, out var standing))
+            return;
+
+        if (standing.Standing)
+            _standing.Down(uid, playSound: false, dropHeldItems: false);
+        else
+            _standing.Stand(uid);
+    }
+}

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -169,6 +169,7 @@ ui-options-function-point = Point at location
 ui-options-function-rotate-object-clockwise = Rotate clockwise
 ui-options-function-rotate-object-counterclockwise = Rotate counterclockwise
 ui-options-function-flip-object = Flip
+ui-options-function-toggle-prone = Toggle lie/stand
 
 ui-options-function-focus-chat-input-window = Focus chat
 ui-options-function-focus-local-chat-window = Focus chat (IC)

--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -44,6 +44,7 @@
   Carried objects and afflictions influence your movement speed, but you can also hold [color=yellow][bold][keybind="Walk"][/bold][/color] to [color=cyan]walk[/color].
   This reduces your speed and helps you avoid [color=cyan]slipping[/color] and falling over when walking over slippery hazards like banana peels or spills.
   \n[italic]Note: walking can be switched to a [bolditalic]toggle[/bolditalic] in the controls menu.[/italic]
+  Press [color=yellow][bold][keybind="ToggleProne"][/bold][/color] to quickly lie down or stand up without dropping items.
 
   ### Spacewalks
   If you find yourself in [color=#EB2D3A]zero gravity[/color], you'll still be able to move — although with reduced friction — as long as you're within reach of any structure.

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -262,6 +262,10 @@ binds:
   type: State
   key: V
   mod1: Shift
+- function: ToggleProne
+  type: State
+  key: N
+  mod1: Shift
 - function: ShowDebugConsole
   type: State
   key: Tilde


### PR DESCRIPTION
## Summary
- add `ToggleProne` bound key function
- register the key function in the human input context
- default bind Shift+N
- expose key in rebind menu and localization
- document the key in the new player guide
- implement `ToggleProneSystem` handling the key

## Testing
- `dotnet test --no-build --verbosity quiet`